### PR TITLE
fix translate with timestamps

### DIFF
--- a/speech_translate/utils/Helper_Whisper.py
+++ b/speech_translate/utils/Helper_Whisper.py
@@ -74,6 +74,35 @@ def srt_whisper_to_txt_format(srt: str):
         text.append(line.strip())
     return "\n".join(text)
 
+def srt_whisper_to_txt_format_stamps(srt: str):
+    """
+    Convert SRT format to text format, and return stamps
+    """
+    text = []
+    stamps = []
+    for line in srt.splitlines():
+        if line.strip().isdigit():
+            continue
+        if "-->" in line:
+            stamps.append(line)
+            continue
+        if line.strip() == "":
+            continue
+        text.append(line.strip())
+    return "\n".join(text), stamps
+
+def txt_to_srt_whisper_format_stamps(txt: str, stamps:list[str]):
+    """
+    Convert text format to SRT format, require list of stamps
+    """
+    srt = []
+    for idx,(line,stamp) in enumerate(zip(txt.splitlines(),stamps)):
+        srt.append(str(idx+1))
+        srt.append(stamp.strip())
+        srt.append(line.strip())
+        srt.append("")
+    return "\n".join(srt)
+
 
 decodingDict = {
     "sample_len": int,


### PR DESCRIPTION
Very nice project! It helps me a lot when making subtitles. However, there is a minor problem with the translation of non-English languages.

### Problem:

Translating SRT with timestamps will bring two problems.

#### 1. Cause wrong SRT format with indexes

e.g. when translating to Chinese, "个" and "四" will spoil the format

```
1个
00:00:00,000 --> 00:00:02,000
……

2个
00:00:06,400 --> 00:00:08,400
已经是时候了...

3个
00:00:10,080 --> 00:00:13,760
做早餐的时候发现晚了。。。

四
00:00:16,000 --> 00:00:18,000
我还没醒...
```

#### 2. Redundant api request for lines with time stamps

### Fix:

Convert SRT to text before translation and save the timestamps for a later recovering.